### PR TITLE
Receive an AudioContext instead of creating one.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 // courtesy of http://noisehack.com/generate-noise-web-audio-api/
-module.exports = function(length, type) {
+module.exports = function(context, length, type) {
   type = type || 'white';
+  length = length || 0;
 
-  var sampleRate = 44100;
+  var sampleRate = context.sampleRate;
   var samples = length * sampleRate;
-  var context = new (window.OfflineAudioContext || window.webkitOfflineAudioContext)(1, samples, sampleRate);
   var noiseBuffer = context.createBuffer(1, samples, sampleRate);
   var output = noiseBuffer.getChannelData(0);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noise-buffer",
-  "version": "2.0.1",
-  "description": "Generate `AudioBuffer`s of white noise.",
+  "version": "3.0.0",
+  "description": "Generate `AudioBuffer`s of noise.",
   "repository": "github:itsjoesullivan/noise-buffer",
   "main": "index.js",
   "author": "itsjoesullivan",

--- a/readme.md
+++ b/readme.md
@@ -11,9 +11,10 @@ Code taken from [NoiseHack.com](http://noisehack.com/generate-noise-web-audio-ap
 ```javascript
 var NoiseBuffer = require('noise-buffer');
 
-var noise = NoiseBuffer(1); // One second of white noise
-var noise = NoiseBuffer(1, 'pink'); // One second of pink noise
-var noise = NoiseBuffer(1, 'brown'); // One second of brown noise
+var ac = new AudioContext()
+var noise = NoiseBuffer(ac, 1); // One second of white noise
+var noise = NoiseBuffer(ac, 1, 'pink'); // One second of pink noise
+var noise = NoiseBuffer(ac, 1, 'brown'); // One second of brown noise
 
 noise instanceof AudioBuffer // true
 ```


### PR DESCRIPTION
The main motivation of this change is be able to use it outside a browser context (where the old `new window.AudioContext` fails), for example with web-audio-test-api.

Also, since you're dealing with AudioBuffers, probably you've created an AudioContext before, so there's no need to create another one. 

With this change, the sampleRate is obtained from the original context (instead of fixing to 44100).

Finally, since is an breaking API change, the version number changed to 3.0.0
